### PR TITLE
ci: add python 3.14 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         os:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- Add Python 3.14 to the CI test matrix