### PR TITLE
fix: temp RH Baro Pro S is not parsed

### DIFF
--- a/src/qingping_ble/parser.py
+++ b/src/qingping_ble/parser.py
@@ -48,6 +48,7 @@ DEVICE_TYPES = {
     0x18: QingpingDevice("CGP23W", "Temp & RH Monitor Pro"),
     0x1E: QingpingDevice("CGC1", "BT Clock Lite"),
     0x24: QingpingDevice("CGDN1", "Air Monitor Lite"),
+    0x26: QingpingDevice("CGP23W", "Temp RH Baro Pro S"),
     0x33: QingpingDevice("CGP22C", "CO2 Temp RH"),
     0x4F: QingpingDevice("CGG3", "Temp RH M"),
     0x5D: QingpingDevice("CGP22C", "CO2 Temp RH"),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1723,7 +1723,8 @@ def test_cgp23w_temp_rh_baro_pro_s_real_data() -> None:
         DeviceKey(key="humidity", device_id=None)
     ].native_value == pytest.approx(44.2)
     assert (
-        parsed.entity_values[DeviceKey(key="battery", device_id=None)].native_value == 62
+        parsed.entity_values[DeviceKey(key="battery", device_id=None)].native_value
+        == 62
     )
     assert parsed.entity_values[
         DeviceKey(key="pressure", device_id=None)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1691,6 +1691,45 @@ def test_cgp23w_real_data() -> None:
     )
 
 
+def test_cgp23w_temp_rh_baro_pro_s_real_data() -> None:
+    """Test with real CGP23W Temp RH Baro Pro S data using device type 0x26."""
+    parser = QingpingBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="Qingping Temp RH Baro Pro S",
+        manufacturer_data={},
+        service_uuids=[],
+        address="58:2D:34:81:9F:3C",
+        rssi=-59,
+        service_data={
+            "0000fdcd-0000-1000-8000-00805f9b34fb": (
+                b"\x88&<\x9f\x814-X\x01\x048\x01\xba\x01\x02\x01>\x07\x02\xbb%"
+            )
+        },
+        source="local",
+    )
+
+    parsed = parser.update(service_info)
+    assert parsed.devices[None] == SensorDeviceInfo(
+        name="Temp RH Baro Pro S 9F3C",
+        model="CGP23W",
+        manufacturer="Qingping",
+        sw_version=None,
+        hw_version=None,
+    )
+    assert parsed.entity_values[
+        DeviceKey(key="temperature", device_id=None)
+    ].native_value == pytest.approx(31.2)
+    assert parsed.entity_values[
+        DeviceKey(key="humidity", device_id=None)
+    ].native_value == pytest.approx(44.2)
+    assert (
+        parsed.entity_values[DeviceKey(key="battery", device_id=None)].native_value == 62
+    )
+    assert parsed.entity_values[
+        DeviceKey(key="pressure", device_id=None)
+    ].native_value == pytest.approx(965.9)
+
+
 def test_empty_service_data_does_not_crash():
     """A Qingping advertisement with empty service data must not raise."""
     info = BluetoothServiceInfo(


### PR DESCRIPTION
Add anothor temperature/humidity and pressure sensor.

Using the following script to capture data:

```python
# -*- coding: utf-8 -*-
import asyncio
from bleak import BleakScanner, BleakClient, BleakGATTCharacteristic


async def main() -> None:
    async with BleakScanner() as scanner:
        async for device, adv in scanner.advertisement_data():
            if device.address == "58:2D:34:81:9F:3C":
                print("found target device:", device.address)
                print(device.address, adv.rssi, adv.local_name, adv.service_data, adv.manufacturer_data)

asyncio.run(main())
```
got：
```
found target device: 58:2D:34:81:9F:3C
58:2D:34:81:9F:3C -59 Qingping Temp RH Baro Pro S {'0000fdcd-0000-1000-8000-00805f9b34fb': b'\x88&<\x9f\x814-X\x01\x048\x01\xbe\x01\x02\x01>\x07\x02\xbc%'} {}
found target device: 58:2D:34:81:9F:3C
58:2D:34:81:9F:3C -62 Qingping Temp RH Baro Pro S {'0000fdcd-0000-1000-8000-00805f9b34fb': b'\x88&<\x9f\x814-X\x01\x047\x01\xbe\x01\x02\x01>\x07\x02\xbc%'} {}
```

Can confirm it works in homeassistant after this patch.