### PR TITLE
fix: stop reading TLV 0x18 as CO2 on the CGP22C

### DIFF
--- a/src/qingping_ble/parser.py
+++ b/src/qingping_ble/parser.py
@@ -160,13 +160,19 @@ class QingpingBluetoothDeviceData(BluetoothData):
             self.update_predefined_sensor(
                 SensorLibrary.PM10__CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, pm10
             )
-        elif xdata_id in (0x13, 0x18) and xdata_size == 2:
-            # CGP22C firmware >=1.6.0 broadcasts CO2 as TLV id 0x18
-            # instead of 0x13 (see issue #72).
+        elif xdata_id == 0x13 and xdata_size == 2:
             (co2,) = UNPACK_CO2(xdata)
             self.update_predefined_sensor(
                 SensorLibrary.CO2__CONCENTRATION_PARTS_PER_MILLION, co2
             )
+        elif xdata_id == 0x18 and xdata_size == 2:
+            # Static 2-byte hardware capability bitmap (screen type, power
+            # source, Wi-Fi capabilities, ...), not a sensor reading. On the
+            # CGP22C it is always 0x0122, which #96 misread as CO2 and used to
+            # overwrite the real 0x13 value with a constant 290 ppm (#72, #115).
+            # CO2 is always broadcast as TLV id 0x13; confirmed against
+            # Qingping's internal BLE protocol spec in #115.
+            pass
         elif xdata_id == 0x0F and xdata_size == 1:
             pass
             # packet_id = unpack("B", xdata)[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1247,49 +1247,63 @@ def test_cgp22c_real_data() -> None:
     )
 
 
-def test_cgp22c_firmware_1_6_0_co2_tlv_0x18() -> None:
-    """Test CGP22C with firmware 1.6.0 sending CO2 as TLV id 0x18.
+def test_cgp22c_tlv_0x18_is_not_co2() -> None:
+    """TLV id 0x18 is a static hardware bitmap, not CO2 (issues #72, #115).
 
-    Firmware 1.6.0 changed CO2 from TLV 0x13 to 0x18. The firmware itself
-    has a regression where the CO2 value is stuck (see issue #72), but the
-    library should still parse it so updated firmware will work seamlessly.
+    The CGP22C alternates between a temperature/humidity frame and a CO2
+    frame; both frames carry a constant ``0x18`` field (``0x0122`` = 290).
+    #96 misread ``0x18`` as CO2, so the real ``0x13`` reading was overwritten
+    with 290 ppm on every frame. The parser must only trust ``0x13``.
+
+    Frames captured on firmware 1.9.9 (MAC bytes anonymised):
+
+    - temp/hum: ``08 5d ffeeddccbbaa 01 04 0d010e02 02 01 64 18 02 2201``
+    - CO2:      ``08 5d ffeeddccbbaa 13 02 7d03     02 01 64 18 02 2201``
     """
+    co2_key = DeviceKey(key="carbon_dioxide", device_id=None)
+
+    def frame(payload: bytes) -> BluetoothServiceInfo:
+        return BluetoothServiceInfo(
+            name="Qingping CO2 Temp RH",
+            manufacturer_data={},
+            service_uuids=[],
+            address="58:2D:34:FF:EE:DD",
+            rssi=-53,
+            service_data={"0000fdcd-0000-1000-8000-00805f9b34fb": payload},
+            source="local",
+        )
+
+    temp_hum_frame = frame(
+        b"\x08\x5d\xff\xee\xdd\xcc\xbb\xaa"
+        b"\x01\x04\x0d\x01\x0e\x02"
+        b"\x02\x01\x64"
+        b"\x18\x02\x22\x01"
+    )
+    co2_frame = frame(
+        b"\x08\x5d\xff\xee\xdd\xcc\xbb\xaa\x13\x02\x7d\x03\x02\x01\x64\x18\x02\x22\x01"
+    )
+
     parser = QingpingBluetoothDeviceData()
-    service_info = BluetoothServiceInfo(
-        name="Qingping CO2 Temp RH",
-        manufacturer_data={},
-        service_uuids=[],
-        address="58:2D:34:87:28:C6",
-        rssi=-71,
-        service_data={
-            "0000fdcd-0000-1000-8000-00805f9b34fb": (
-                b"\x08\x5d\xc6\x28\x87\x34\x2d\x58"
-                b"\x01\x04\xd2\x00\x44\x02"
-                b"\x02\x01\x64"
-                b"\x18\x02\x22\x01"
-            )
-        },
-        source="28:0C:50:E0:9D:AD",
-    )
-    parsed = parser.update(service_info)
-    assert (
-        parsed.entity_values[
-            DeviceKey(key="carbon_dioxide", device_id=None)
-        ].native_value
-        == 290
-    )
+
+    # A temp/hum frame carries 0x18 but no 0x13 -> no CO2 value at all.
+    parsed = parser.update(temp_hum_frame)
+    assert co2_key not in parsed.entity_values
     assert (
         parsed.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
-        == 21.0
+        == 26.9
     )
     assert (
         parsed.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
-        == 58.0
+        == 52.6
     )
-    assert (
-        parsed.entity_values[DeviceKey(key="battery", device_id=None)].native_value
-        == 100
-    )
+
+    # The CO2 frame reports the real value from 0x13.
+    parsed = parser.update(co2_frame)
+    assert parsed.entity_values[co2_key].native_value == 893
+
+    # A following temp/hum frame must not clobber it back to 290.
+    parsed = parser.update(temp_hum_frame)
+    assert parsed.entity_values[co2_key].native_value == 893
 
 
 def test_motion_and_light_high_illuminance() -> None:


### PR DESCRIPTION
## Summary

`0x18` is **not** CO2 — it's a static 2-byte hardware capability bitmap (screen type, power source, Wi-Fi capabilities, …). On the CGP22C it is always `0x0122` (= 290) and appears in *every* advertisement, alongside the real CO2 which is still broadcast as TLV `0x13` on all firmware (1.3.8 / 1.6.0 / 1.9.9).

Since #96 added `0x18` to the CO2 branch of `_process_xdata`, that constant 290 overwrites the real `0x13` value on every CO2 frame, and the temperature/humidity frames (which carry `0x18` but no `0x13`) publish CO2 = 290 too. Net effect: **CO2 has been pinned at 290 ppm for every CGP22C user since `qingping-ble` 1.1.2**, regardless of firmware. 290 ppm is also below the sensor's 400–9999 ppm spec range.

#96 was based on a misdiagnosis in #72 (a battery-powered device that advertises the CO2 frame rarely, so the `0x13` frame just wasn't captured). Qingping (@tengfeili-qingping) confirmed in #115, against their internal BLE protocol spec, that `0x18` is a hardware bitmap and `0x13` is the correct CO2 id.

## Changes

- `_process_xdata`: only `0x13` is CO2. `0x18` is handled as an explicit no-op with a comment, so it doesn't hit the "Unknown data" debug log.
- Replace `test_cgp22c_firmware_1_6_0_co2_tlv_0x18` with `test_cgp22c_tlv_0x18_is_not_co2`, using real firmware 1.9.9 frames from #115: a temp/humidity frame produces **no** CO2 value, the CO2 frame reports the real 893 ppm from `0x13`, and a following temp/humidity frame does **not** clobber it back to 290.

## Test plan

- `pytest tests/` — 35 passed, 100% coverage.

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
