### PR TITLE
chore(pre-commit.ci): pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ ci:
 
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.2
+    rev: v4.18.0
     hooks:
       - id: commitizen
         stages: [commit-msg]
@@ -39,17 +39,17 @@ repos:
       - id: pyupgrade
         args: [--py310-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.14
+    rev: v0.16.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.3.1
     hooks:
       - id: mypy
         additional_dependencies: []

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This is a shim to allow GitHub to detect the package, build is done with poetry
 # Taken from https://github.com/Textualize/rich
 

--- a/src/qingping_ble/__init__.py
+++ b/src/qingping_ble/__init__.py
@@ -26,7 +26,6 @@ __all__ = [
     "SensorDescription",
     "SensorDeviceClass",
     "SensorDeviceInfo",
-    "SensorDeviceInfo",
     "SensorUpdate",
     "SensorValue",
     "Units",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,5 @@
+import pytest
 from bluetooth_sensor_state_data import BluetoothServiceInfo, SensorUpdate
-from qingping_ble.parser import QingpingBluetoothDeviceData
 from sensor_state_data import (
     BinarySensorDescription,
     BinarySensorDeviceClass,
@@ -12,7 +12,7 @@ from sensor_state_data import (
     Units,
 )
 
-import pytest
+from qingping_ble.parser import QingpingBluetoothDeviceData
 
 
 def test_can_create():


### PR DESCRIPTION
Rebased #103 onto main and fixed the lint failure. The ruff bump enables EXE001, which flags the shebang in the setup.py shim since the file is not executable; the shebang is not needed there so it is removed.

Closes #103